### PR TITLE
empty: fix Makefile

### DIFF
--- a/pkgs/tools/misc/empty/0.6-Makefile.patch
+++ b/pkgs/tools/misc/empty/0.6-Makefile.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile b/Makefile
+index 1fe4c41..2c69558 100644
+--- a/Makefile
++++ b/Makefile
+@@ -16,7 +16,7 @@ LIBS =	-lutil
+ PREFIX = /usr/local
+ 
+ all:
+-	${CC} ${CFLAGS} -Wall ${LIBS} -o empty empty.c
++	${CC} ${CFLAGS} -Wall -o empty empty.c ${LIBS}
+ 
+ FreeBSD:	all
+ NetBSD:		all

--- a/pkgs/tools/misc/empty/default.nix
+++ b/pkgs/tools/misc/empty/default.nix
@@ -10,14 +10,16 @@ stdenv.mkDerivation rec {
     stripRoot = false;
   };
 
+  patches = [
+    ./0.6-Makefile.patch
+  ];
+
   nativeBuildInputs = [ which ];
 
   makeFlags = [ "PREFIX=$(out)" ];
 
-  # Allow installation prefix to be overridden, and fix the CC parameter order.
-  prePatch = ''
-    substituteInPlace Makefile \
-      --replace '\$\{LIBS\} -o empty empty.c' '-o empty empty.c \$\{LIBS\}'
+  postPatch = ''
+    rm empty
   '';
 
   meta = with lib; {


### PR DESCRIPTION
###### Motivation for this change

https://github.com/NixOS/nixpkgs/pull/116067#discussion_r600641921

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](https://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `sandbox` in [`nix.conf`](https://nixos.org/nix/manual/#sec-conf-file) on non-NixOS linux)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [X] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nixpkgs-review --run "nixpkgs-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Determined the impact on package closure size (by running `nix path-info -S` before and after)
